### PR TITLE
deleting robot_pose_publisher from launch file

### DIFF
--- a/marathon_touch_gui/launch/marathon_gui_dependencies.launch
+++ b/marathon_touch_gui/launch/marathon_gui_dependencies.launch
@@ -2,7 +2,6 @@
 	
 	<include file="$(find rosbridge_server)/launch/rosbridge_websocket.launch" />
 	
-	<node pkg="robot_pose_publisher" type="robot_pose_publisher" name="robot_pose_publisher" />
 	<node pkg="tf2_web_republisher" type="tf2_web_republisher" name="tf2_web_republisher" />
 
 	<node pkg="strands_webserver" type="strands_webserver" name="strands_webserver" />


### PR DESCRIPTION
now the pose publisher is always brought up by scitos_bringup, given that it was added to scitos_state_publisher.launch
