### PR TITLE
Added support for multiple webservers.

### DIFF
--- a/strands_webserver/data/example-page.html
+++ b/strands_webserver/data/example-page.html
@@ -1,4 +1,4 @@
-}<!DOCTYPE html>
+<!DOCTYPE html>
 <html lang="en">
 <head>
   <meta charset="utf-8">

--- a/strands_webserver/data/example-page.html
+++ b/strands_webserver/data/example-page.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+}<!DOCTYPE html>
 <html lang="en">
 <head>
   <meta charset="utf-8">

--- a/strands_webserver/data/main.html
+++ b/strands_webserver/data/main.html
@@ -1,3 +1,5 @@
+$def with (name)
+
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -92,7 +94,7 @@
                 console.log("Trying to setup");
                 page_topic = new ROSLIB.Topic({
                     ros : ros,
-                    name : '/strands_webserver/display_' + window.display_number + '/page',
+                    name : '$:name/display_' + window.display_number + '/page',
                     messageType : 'std_msgs/String'
                 });
                 page_topic.subscribe(function(message) {
@@ -122,7 +124,7 @@
             // Register the display with the manager
             var registerDisplayClient = new ROSLIB.Service({
                 ros : ros,
-                name : '/strands_webserver/register_display',
+                name : '$:name/register_display',
                 serviceType : 'strands_webserver/RegisterDisplay'
             });
 
@@ -140,7 +142,7 @@
                 shutdown();
                 var unregisterDisplayClient = new ROSLIB.Service({
                     ros : ros,
-                    name : '/strands_webserver/unregister_display',
+                    name : '$:name/unregister_display',
                     serviceType : 'strands_webserver/UnregisterDisplay'
                 });
 

--- a/strands_webserver/scripts/strands_webserver
+++ b/strands_webserver/scripts/strands_webserver
@@ -6,9 +6,9 @@ This is a display server for HRI information display.
 
 It is a webserver that runs on localhost. When a request comes in for the main
 page, ie http://localhost/, a page is served that uses roslibjs to register the display. The display is assigned a number 1..10. 
-rosjs/rosbridge. The page subscribes to /strands_webserver/display_%d/page (std_msgs/String) using rosbridge. When a URL is received on this topic, it gets displayed inside an IFrame.
+rosjs/rosbridge. The page subscribes to rospy.get_name/display_%d/page (std_msgs/String) using rosbridge. When a URL is received on this topic, it gets displayed inside an IFrame.
 
-A service is provided for triggering a different page to be shown: /strands_webserver/display_page. This just checks the display is registered and sends publishes data on the topic.
+A service is provided for triggering a different page to be shown: rospy.get_name/display_page. This just checks the display is registered and sends publishes data on the topic.
 
 Page can be either HTML or URL. The page can make use of rosbridge to publish/subscribe to topics and call services.
 
@@ -18,6 +18,8 @@ In addition to the server, there are some "standard" template pages that can be 
 
 import sys
 import os
+import web
+
 import roslib
 import rospy
 from  threading import Timer
@@ -29,6 +31,10 @@ from std_msgs.msg import String
 
 from  BaseHTTPServer import HTTPServer
 from SimpleHTTPServer import SimpleHTTPRequestHandler
+
+
+template_dir = roslib.packages.get_pkg_dir('strands_webserver') + '/data'
+render = web.template.render(template_dir)
 
 
 class DisplayWebHandler(SimpleHTTPRequestHandler):
@@ -52,9 +58,9 @@ class DisplayWebHandler(SimpleHTTPRequestHandler):
             self.send_header('Content-type','text/html')
             self.end_headers()
             # Send the page
-            with open(os.path.join(roslib.packages.get_pkg_dir("strands_webserver"),
-                                   "data/main.html"),"r") as f:
-                data = f.read()
+            name = rospy.get_name()
+            data = render.main(name)
+
             # Populate dynamic fields
             # todo: this currently produces an odd result for me, so returning to hard coded url in main.html
             # hostname = self.server.server_name
@@ -144,7 +150,7 @@ class RosControlInterface(object):
         # set up services
         for s in dir(self):
             if s.endswith("_srv_cb"):
-                rospy.Service("/strands_webserver/"+s[:-7],
+                rospy.Service(rospy.get_name() + "/"+s[:-7],
                               getattr(self,s).type, getattr(self,s))
                 
 
@@ -160,7 +166,7 @@ class RosControlInterface(object):
         new_no=self._displays_available.pop()
         rospy.loginfo("Registering display, id=%d", new_no)
         self._displays.append( (new_no,
-                                rospy.Publisher("/strands_webserver/display_%d/page"%new_no, String ) )
+                                rospy.Publisher(rospy.get_name() + "/display_%d/page"%new_no, String ) )
                                )
         return self._displays[-1][0]
     register_display_srv_cb.type=RegisterDisplay

--- a/strands_webserver/scripts/strands_webserver_demo.py
+++ b/strands_webserver/scripts/strands_webserver_demo.py
@@ -12,29 +12,31 @@ import std_srvs.srv
 
 def trigger_pleading(req):
       print 'please, please help'
-
+      return std_srvs.srv.EmptyResponse()
 
 def party_time(req):
       print 'woo, off I go baby'
+      return std_srvs.srv.EmptyResponse()
 
 
 if __name__ == '__main__':
 	rospy.init_node("strands_webserver_demo")
 	# The display to publish on, defaulting to all displays
 	display_no = rospy.get_param("~display", 0)	
+	prefix = rospy.get_param("~prefix", '/strands_webserver')	
 
 	# display a start-up page
-	strands_webserver.client_utils.display_url(display_no, 'http://strands-project.eu')
+	strands_webserver.client_utils.display_url(display_no, 'http://strands-project.eu', prefix)
 
 	# sleep for 5 seconds
 	rospy.sleep(5.)
 
 	# tell the webserver where it should look for web files to serve
 	http_root = os.path.join(roslib.packages.get_pkg_dir("strands_webserver"), "data")
-	strands_webserver.client_utils.set_http_root(http_root)
+	strands_webserver.client_utils.set_http_root(http_root, prefix)
 
 	# start with a basic page pretending things are going normally
-	strands_webserver.client_utils.display_relative_page(display_no, 'example-page.html')
+	strands_webserver.client_utils.display_relative_page(display_no, 'example-page.html', prefix)
 
 	# sleep for 5 seconds
 	rospy.sleep(5.)
@@ -44,7 +46,7 @@ if __name__ == '__main__':
 	buttons = [('No', 'trigger_pleading'), ('Sure', 'party_time')]
 	service_prefix = '/caller_services'
 	content = strands_webserver.page_utils.generate_alert_button_page(notice, buttons, service_prefix)	
-	strands_webserver.client_utils.display_content(display_no, content) 
+	strands_webserver.client_utils.display_content(display_no, content, prefix) 
 	rospy.Service('/caller_services/trigger_pleading', std_srvs.srv.Empty, trigger_pleading) 
 	rospy.Service('/caller_services/party_time', std_srvs.srv.Empty, party_time) 
 	rospy.spin()

--- a/strands_webserver/src/strands_webserver/client_utils.py
+++ b/strands_webserver/src/strands_webserver/client_utils.py
@@ -7,9 +7,9 @@ from strands_webserver.srv import *
 from std_msgs.msg import String
 
 """ switch the webserver to server pages from dir """
-def set_http_root(dir):
-	rospy.wait_for_service('/strands_webserver/set_http_root')
- 	set_http_root = rospy.ServiceProxy('/strands_webserver/set_http_root', SetRoot)
+def set_http_root(dir, prefix='/strands_webserver'):
+	rospy.wait_for_service(prefix + '/set_http_root')
+ 	set_http_root = rospy.ServiceProxy(prefix + '/set_http_root', SetRoot)
 	try:
   		resp = set_http_root(dir)
 	except rospy.ServiceException as exc:
@@ -18,11 +18,11 @@ def set_http_root(dir):
 
 
 """ tell server to display the page relative to server root """
-def display_relative_page(displayNo, page):
-	rospy.wait_for_service('/strands_webserver/display_page')
-	rospy.wait_for_service('/strands_webserver/get_hostname')
- 	display_page = rospy.ServiceProxy('/strands_webserver/display_page', SetDisplay)
- 	get_hostname = rospy.ServiceProxy('/strands_webserver/get_hostname', GetServerAddress)
+def display_relative_page(displayNo, page, prefix='/strands_webserver'):
+	rospy.wait_for_service(prefix + '/display_page')
+	rospy.wait_for_service(prefix + '/get_hostname')
+ 	display_page = rospy.ServiceProxy(prefix + '/display_page', SetDisplay)
+ 	get_hostname = rospy.ServiceProxy(prefix + '/get_hostname', GetServerAddress)
 	try:
 		resp = get_hostname()
 		server = 'http://%s:%d/' % (resp.hostname, resp.port) 
@@ -31,18 +31,19 @@ def display_relative_page(displayNo, page):
   		print("Service did not process request: " + str(exc))
 
 """ tell server to display an arbitrary url -- this must start with http """
-def display_url(displayNo, url):
-	rospy.wait_for_service('/strands_webserver/display_page')
- 	display_page = rospy.ServiceProxy('/strands_webserver/display_page', SetDisplay)
+def display_url(displayNo, url, prefix='/strands_webserver'):
+	rospy.wait_for_service(prefix + '/display_page')
+ 	display_page = rospy.ServiceProxy(prefix + '/display_page', SetDisplay)
+ 	print display_page
 	try:
   		resp = display_page(displayNo, url)
 	except rospy.ServiceException as exc:
   		print("Service did not process request: " + str(exc))
 
 """ tell server to display the provided html content """
-def display_content(displayNo, html):
-	rospy.wait_for_service('/strands_webserver/display_page')
- 	display_page = rospy.ServiceProxy('/strands_webserver/display_page', SetDisplay)
+def display_content(displayNo, html, prefix='/strands_webserver'):
+	rospy.wait_for_service(prefix + '/display_page')
+ 	display_page = rospy.ServiceProxy(prefix + '/display_page', SetDisplay)
 	try:
   		resp = display_page(displayNo, html)
 	except rospy.ServiceException as exc:


### PR DESCRIPTION
The webserver now uses its name to define the service prefix. This means you can run multiple webservers in parallel to show different things, or hosted on different machines, but within the same ros system.

Default behaviour remains unchanged, i.e. launched with:

```
rosrun strands_webserver strands_webserver
```

To run an extra server in parallel on port 8091 with service prefix /bob

```
rosrun strands_webserver strands_webserver __name:=bob _port:=8091
```
