### PR TITLE
Removed nav_help_s* packages from metapackage run_dependencies. 

### DIFF
--- a/strands_ui/package.xml
+++ b/strands_ui/package.xml
@@ -14,8 +14,6 @@
 
   <buildtool_depend>catkin</buildtool_depend>
   <run_depend>mary_tts</run_depend>
-  <run_depend>nav_help_screen</run_depend>
-  <run_depend>nav_help_speech</run_depend>
   <run_depend>rosbridge_server</run_depend>
   <run_depend>strands_webserver</run_depend>
   <run_depend>tf2_web_republisher</run_depend>


### PR DESCRIPTION
They are now in the recovery behaviour package.
