### PR TITLE
Add environment variable to select startup voice.

### DIFF
--- a/mary_tts/launch/ros_mary.launch
+++ b/mary_tts/launch/ros_mary.launch
@@ -1,4 +1,6 @@
 <launch>
 	<node name="maryserver" pkg="mary_tts" type="marytts-server.sh" cwd="node"/>
-	<node name="ros_mary_bridge" pkg="mary_tts" type="marybridge.py" output="screen" respawn="true"/>
+	<node name="ros_mary_bridge" pkg="mary_tts" type="marybridge.py" output="screen" respawn="true">
+	      <param name="voice" value="$(optenv TTS_VOICE dfki-prudence-hsmm)" type="string"/>
+	</node>
 </launch>

--- a/mary_tts/scripts/marybridge.py
+++ b/mary_tts/scripts/marybridge.py
@@ -61,7 +61,7 @@ class RosMary(object):
         voice = rospy.get_param("~voice")
         print "Selected locale:", self.mary_client.locale
         if voice not in self._voices:
-            rospy.logwarn("Selected voice '%s'not available, using default!"%voice)
+            rospy.logwarn("Selected voice '%s' not available, using default!"%voice)
         else:
             self.mary_client.voice = voice
             print "Selected voice:", self.mary_client.voice

--- a/mary_tts/scripts/marybridge.py
+++ b/mary_tts/scripts/marybridge.py
@@ -58,8 +58,13 @@ class RosMary(object):
                 voice = i[6:i.find("-5.0")]
                 print " - ",voice
                 self._voices.append(voice)
+        voice = rospy.get_param("~voice")
         print "Selected locale:", self.mary_client.locale
-        print "Selected voice:", self.mary_client.voice
+        if voice not in self._voices:
+            rospy.logwarn("Selected voice '%s'not available, using default!"%voice)
+        else:
+            self.mary_client.voice = voice
+            print "Selected voice:", self.mary_client.voice
 
     def speak(self,req):
         """ Speak service handler """


### PR DESCRIPTION
This changes the marybridge so that the voice used can be set using an environment variable. The environement variable is `TTS_VOICE` which can either be set in the `.bashrc`:

```
export TTS_VOICE=dfki-spike-hsmm
```

or at each launch:

```
TTS_VOICE=dfki-spike-hsmma roslaunch mary_tts ros_mary.launch
```

The set of voices available remains the same:
-  dfki-obadiah-hsmm
-  dfki-pavoque-neutral-hsmm
-  bits3-hsmm
-  dfki-prudence-hsmm
-  cmu-slt-hsmm
-  bits1-hsmm
-  dfki-spike-hsmm
-  dfki-poppy-hsmm

The reason for this PR is to avoid the need for users to call the `/marytts/set_voice` service after starting mary.
