### PR TITLE
Adding button page that uses a service giving you the label of the button

### DIFF
--- a/strands_webserver/CMakeLists.txt
+++ b/strands_webserver/CMakeLists.txt
@@ -41,6 +41,7 @@ add_service_files(
   SetRoot.srv
   SetDisplay.srv
   GetServerAddress.srv
+  CallButton.srv
 )
 
 ## Generate actions in the 'action' folder

--- a/strands_webserver/scripts/strands_webserver_demo.py
+++ b/strands_webserver/scripts/strands_webserver_demo.py
@@ -7,7 +7,7 @@ import rospy
 
 import strands_webserver.page_utils
 import strands_webserver.client_utils
-import std_srvs.srv 
+import std_srvs.srv
 
 
 def trigger_pleading(req):
@@ -22,8 +22,8 @@ def party_time(req):
 if __name__ == '__main__':
 	rospy.init_node("strands_webserver_demo")
 	# The display to publish on, defaulting to all displays
-	display_no = rospy.get_param("~display", 0)	
-	prefix = rospy.get_param("~prefix", '/strands_webserver')	
+	display_no = rospy.get_param("~display", 0)
+	prefix = rospy.get_param("~prefix", '/strands_webserver')
 
 	# display a start-up page
 	strands_webserver.client_utils.display_url(display_no, 'http://strands-project.eu', prefix)
@@ -45,8 +45,8 @@ if __name__ == '__main__':
 	notice = 'Help me, I am <em>stuck</em>'
 	buttons = [('No', 'trigger_pleading'), ('Sure', 'party_time')]
 	service_prefix = '/caller_services'
-	content = strands_webserver.page_utils.generate_alert_button_page(notice, buttons, service_prefix)	
-	strands_webserver.client_utils.display_content(display_no, content, prefix) 
-	rospy.Service('/caller_services/trigger_pleading', std_srvs.srv.Empty, trigger_pleading) 
-	rospy.Service('/caller_services/party_time', std_srvs.srv.Empty, party_time) 
+	content = strands_webserver.page_utils.generate_alert_button_page(notice, buttons, service_prefix)
+	strands_webserver.client_utils.display_content(display_no, content, prefix)
+	rospy.Service('/caller_services/trigger_pleading', std_srvs.srv.Empty, trigger_pleading)
+	rospy.Service('/caller_services/party_time', std_srvs.srv.Empty, party_time)
 	rospy.spin()

--- a/strands_webserver/src/strands_webserver/page_utils.py
+++ b/strands_webserver/src/strands_webserver/page_utils.py
@@ -28,11 +28,20 @@ def generate_two_column_page(file_name, target_dir, left = "", right = "", scrip
 """
 Uses web.py to generate html for the body of a page which contains an arbitrary html notice with buttons below. Buttons should be specified as a list of (label, service) tuples where clicking on the button with label will call /service_prefix/service. Html will work in the body of the main page served by strands_webserver.
 """
-def generate_button_page(notice, buttons, service_prefix):
-	return str(render.buttons_multi_service(notice, buttons, service_prefix))
+def generate_button_page(notice, buttons, service_prefix, template="multi_service"):
+    if template == "multi_service":
+        return str(render.buttons_multi_service(notice, buttons, service_prefix))
+    elif template == "named_service":
+        return str(render.buttons_named_service(notice, buttons, service_prefix))
 
 """
 Uses web.py to generate html for the body of a page which contains a large text notice with buttons below. Buttons should be specified as a list of (label, service) tuples where clicking on the button with label will call /service_prefix/service. Html will work in the body of the main page served by strands_webserver.
 """
 def generate_alert_button_page(notice, buttons, service_prefix):
-	return generate_button_page('<div class="notice">' + notice + '</div>', buttons, service_prefix)
+	return generate_button_page('<div class="notice">' + notice + '</div>', buttons, service_prefix, template="multi_service")
+
+"""
+Uses web.py to generate html for the body of a page which contains an arbitrary html notice with buttons below. Buttons should be specified as a list of (label, service) tuples where clicking on the button with label will call /service_prefix/service. Html will work in the body of the main page served by strands_webserver.
+"""
+def generate_named_button_page(notice, buttons, service_prefix):
+	return generate_button_page('<div class="notice">' + notice + '</div>', buttons, service_prefix, template="named_service")

--- a/strands_webserver/srv/CallButton.srv
+++ b/strands_webserver/srv/CallButton.srv
@@ -1,0 +1,2 @@
+string name
+---

--- a/strands_webserver/templates/buttons_named_service.html
+++ b/strands_webserver/templates/buttons_named_service.html
@@ -1,0 +1,19 @@
+$def with (notice, buttons, servicePrefix)
+
+<div class="row">
+	<div class="col-md-12">
+		$:notice
+	</div>
+</div>
+<div class="row"> 
+	$ buttonCol = 12/len(buttons)
+	$ colClass = 'col-md-%s' % buttonCol
+	$for (label,service) in buttons: 
+		$ serviceName = '\'%s/%s\'' % (servicePrefix, service)	
+		<div class="$colClass"> 
+			<!-- Sorry this is so ugly, but this seems to be the only way to get the script executed -->
+			<button type="button" onclick="var service_$service = new ROSLIB.Service({ros : ros, name : $:serviceName, serviceType : 'strands_websrver/CallButton'}); var request_$service = new ROSLIB.ServiceRequest({name: &quot;$label&quot;});  service_$service .callService(request_$service, function(result) {console.log('Called service'); }); console.log('Called')" class="btn btn-lg btn-default btn-block">$:label</button>
+		</div> 
+</div>
+
+


### PR DESCRIPTION
Useful for a list of waypoint buttons, where each button calls the same service.

Instead of `strands_webserver.page_utils.generate_alert_button_page` you use `strands_webserver.page_utils.generate_named_button_page` calling the `strands_webserver.srv.CallButton` service. The service request will then contain the button label in the field `name`
