### PR TITLE
[media_server] Add get by filename.

### DIFF
--- a/mongodb_media_server/README.md
+++ b/mongodb_media_server/README.md
@@ -8,7 +8,7 @@ web interface, and is stored in the mongodb database using GridFS.
 
 # Editing the available content
 
-Got to `http://localhost:8027`
+Goto to `http://localhost:8027`
 
 The 'File Manager' tab allows you to upload files of any type. The 'BLAH Sets' 
 tabs allow you to edit the data groupings. For example, the 'Photo Sets' can
@@ -20,7 +20,13 @@ Every file is accessible through:
 
 `http://localhost:8027/get_media/MEDIAKEY`
 
-where MEDIAKEY is the id of the file. The IDs of the files are retrievable
+where MEDIAKEY is the id of the file, or
+
+`http://localhost:8027/get_media_by_name/name`
+
+where name is the filename of the media file.
+
+The IDs of the files are retrievable
 via the Python api. For example, to retrieve the items in a photo album called
 'AAF-Deploy-InfoTerm':
 

--- a/mongodb_media_server/scripts/server.py
+++ b/mongodb_media_server/scripts/server.py
@@ -40,6 +40,7 @@ class MediaServer(web.application):
             sets_expression, 'ViewSets',
             '/put_media', 'UploadFile',
             '/get_media/([a-zA-Z0-9]+)', 'DownloadFile',
+            '/get_media_by_name/(.+)', 'DownloadFileByName',
             '/get_media_thumb/([a-zA-Z0-9]+)', 'GetFileThumbnail',
             '/delete_media/([a-zA-Z0-9]+)', 'DeleteFile',
             '/create_set/([a-zA-Z0-9]+)', 'CreateSet',
@@ -186,6 +187,17 @@ class DownloadFile(object):
     def GET(self, file_id):
         try:
             file_ = filesystem.get(ObjectId(str(file_id)))
+        except Exception, e:
+            print e
+            raise web.notfound()
+        
+        web.header("Content-Type", file_.content_type)
+        return file_.read()
+ 
+class DownloadFileByName(object):  
+    def GET(self, file_name):
+        try:
+            file_ = filesystem.get_last_version(file_name)
         except Exception, e:
             print e
             raise web.notfound()

--- a/mongodb_media_server/www/file_manager.html
+++ b/mongodb_media_server/www/file_manager.html
@@ -43,7 +43,7 @@ $var title: File Manager
 			  <td>$f[1]</td>
 			  <td>$f[2]</td>
 			  <td>$f[3]</td>
-			  <td><a href="/get_media/$f[0]" class="btn" role="button">Download</a>
+			  <td><a href="/get_media_by_name/$f[1]" class="btn" role="button">Download</a>
 				<a href="/delete_media/$f[0]" class="btn" role="button">Delete</a>
 			  </td>
 			</tr>


### PR DESCRIPTION
This allows downloading/accessing of files by filename.  Each file can now be accessed by `http://localhost:8027/get_media_by_name/name` where name is the filename, and the download link on the file manager page will provide a human friendly filename for download.
