### PR TITLE
Adding media server to launch file.

### DIFF
--- a/strands_ui/launch/strands_ui.launch
+++ b/strands_ui/launch/strands_ui.launch
@@ -12,5 +12,6 @@
     <node pkg="strands_webserver" type="strands_webserver" name="strands_webserver" output="screen">
         <param name="host_ip" value="$(optenv HOST_IP 127.0.0.1)" />
     </node>
+    <node pkg="mongodb_media_server" type="server.py" name="mongodb_media_server" />
 
 </launch>


### PR DESCRIPTION
This requires mongodb to run otherwise the media server dies ungracefully.
Not sure if we want that, but having it in a launch file somewhere would be nice.
