### PR TITLE
Adding support to start mary on different machine

### DIFF
--- a/mary_tts/launch/ros_mary.launch
+++ b/mary_tts/launch/ros_mary.launch
@@ -1,6 +1,12 @@
 <launch>
-	<node name="maryserver" pkg="mary_tts" type="marytts-server.sh" cwd="node"/>
+
+        <arg name="machine" default="localhost" />
+        <arg name="user" default="" />
+
+        <machine name="$(arg machine)" address="$(arg machine)" env-loader="$(optenv ROS_ENV_LOADER )" user="$(arg user)" default="false"/>
+	<node name="maryserver" pkg="mary_tts" type="marytts-server.sh" cwd="node" machine="$(arg machine)"/>
 	<node name="ros_mary_bridge" pkg="mary_tts" type="marybridge.py" output="screen" respawn="true">
 	      <param name="voice" value="$(optenv TTS_VOICE dfki-prudence-hsmm)" type="string"/>
+	      <param name="host" value="$(arg machine)" type="string"/>
 	</node>
 </launch>

--- a/mary_tts/scripts/marybridge.py
+++ b/mary_tts/scripts/marybridge.py
@@ -32,6 +32,8 @@ class RosMary(object):
         rospy.Service('ros_mary', ros_mary, self.speak)
         rospy.Service('ros_mary/set_voice', SetVoice, self.set_voice)
         rospy.Service('ros_mary/set_locale', SetLocale, self.set_locale)
+        host = rospy.get_param("~host")
+        self.mary_client.set_host(host)
 
         # What voices are available?
         filelist = os.listdir(os.path.join(roslib.packages.get_pkg_dir("mary_tts"),

--- a/mary_tts/scripts/marybridge.py
+++ b/mary_tts/scripts/marybridge.py
@@ -32,7 +32,7 @@ class RosMary(object):
         rospy.Service('ros_mary', ros_mary, self.speak)
         rospy.Service('ros_mary/set_voice', SetVoice, self.set_voice)
         rospy.Service('ros_mary/set_locale', SetLocale, self.set_locale)
-        host = rospy.get_param("~host")
+        host = rospy.get_param("~host", "localhost")
         self.mary_client.set_host(host)
 
         # What voices are available?

--- a/strands_ui/launch/strands_ui.launch
+++ b/strands_ui/launch/strands_ui.launch
@@ -1,10 +1,15 @@
 <launch>
     <arg name="machine" default="localhost" />
     <arg name="user" default="" />
+    <arg name="mary_machine" default="localhost" />
+    <arg name="mary_machine_user" default="" />
 
     <machine name="$(arg machine)" address="$(arg machine)" env-loader="$(optenv ROS_ENV_LOADER )" user="$(arg user)" default="true"/>
 
-    <include file="$(find mary_tts)/launch/ros_mary.launch"/>
+    <include file="$(find mary_tts)/launch/ros_mary.launch">
+        <arg name="machine" value="$(arg mary_machine)"/>
+        <arg name="user" value="$(arg mary_machine_user)"/>
+    </include>
     <include file="$(find rosbridge_server)/launch/rosbridge_websocket.launch" />
 
     <node pkg="tf2_web_republisher" type="tf2_web_republisher" name="tf2_web_republisher" />


### PR DESCRIPTION
This allows to start the actual mary server on a different machine. Due to limitations in RAM size on the main PC and the java based mary server using quite a bit of it, the mary server can be started on a side PC. This transfers the generated sound file via http to the mary bridge with has to be run on the main PC.

Tested on Linda
