### PR TITLE
add the `notify_all()` on stop event to fix #89

### DIFF
--- a/pygame_managed_player/src/pygame_managed_player/pygame_player.py
+++ b/pygame_managed_player/src/pygame_managed_player/pygame_player.py
@@ -127,6 +127,7 @@ class PyGamePlayer:
         self.__announce_priority(0)
         self.cv.acquire()
         self.playing = e
+        self.cv.notify_all()
         self.cv.release()
         rospy.logdebug('stop event=%d', e-USEREVENT)
 


### PR DESCRIPTION
this fixes a very silly threading bug that caused #89 but could also have effected other components using the `pygame_managed_player`

Maybe @jayyoung who reported #89 can give this a try before merge?
