### PR TITLE
Add content headers for video.

### DIFF
--- a/mongodb_media_server/scripts/server.py
+++ b/mongodb_media_server/scripts/server.py
@@ -193,9 +193,12 @@ class DownloadFile(object):
         except Exception, e:
             print e
             raise web.notfound()
-        
+        content=file_.read()
         web.header("Content-Type", file_.content_type)
-        return file_.read()
+        web.header("Content-Length", len(content))
+        if file_.content_type.startswith("video"):
+            web.header("Accept-Ranges","bytes")
+        return content
  
 class DownloadFileByName(object):  
     def GET(self, file_name):
@@ -205,8 +208,12 @@ class DownloadFileByName(object):
             print e
             raise web.notfound()
         
+        content=file_.read()
         web.header("Content-Type", file_.content_type)
-        return file_.read()
+        web.header("Content-Length", len(content))
+        if file_.content_type.startswith("video"):
+            web.header("Accept-Ranges","bytes")
+        return content
     
 class DeleteFile(object):
     def GET(self, file_id):


### PR DESCRIPTION
This adds "Accept-Ranges" and "Content-Length" headers too the HTTP response for video files. It fixes a problem with playing videos in firefox. I am not 100% sure about only adding the Accept-Ranges field for video files, but @cdondrup has confirmed this works.

Closes #77 
