### PR TITLE
[mary_tts] Allowing to set the locale via parameter using environment variable

### DIFF
--- a/mary_tts/launch/ros_mary.launch
+++ b/mary_tts/launch/ros_mary.launch
@@ -7,6 +7,7 @@
 	<node name="maryserver" pkg="mary_tts" type="marytts-server.sh" cwd="node" machine="$(arg machine)"/>
 	<node name="ros_mary_bridge" pkg="mary_tts" type="marybridge.py" output="screen" respawn="true">
 	      <param name="voice" value="$(optenv TTS_VOICE dfki-prudence-hsmm)" type="string"/>
+              <param name="locale" value="$(optenv TTS_LOCALE en_GB)" type="string"/>
 	      <param name="host" value="$(arg machine)" type="string"/>
 	</node>
 </launch>

--- a/mary_tts/scripts/marybridge.py
+++ b/mary_tts/scripts/marybridge.py
@@ -62,7 +62,12 @@ class RosMary(object):
                 print " - ", voice
                 self._voices.append(voice)
         voice = rospy.get_param("~voice")
-        print "Selected locale:", self.mary_client.locale
+        locale = rospy.get_param("~locale")
+        if locale not in self._locales:
+            rospy.logwarn("Selected voice '%s' not available, using default!" % locale)
+        else:
+            self.mary_client.locale = locale
+            print "Selected locale:", self.mary_client.locale
         if voice not in self._voices:
             rospy.logwarn("Selected voice '%s' not available, using default!" % voice)
         else:


### PR DESCRIPTION
This way

```
export TTS_VOICE=dfki-pavoque-neutral-hsmm
export TTS_LOCALE=de
```

in werner's `.bashrc` makes sure that he always uses a male German voice. More convenient than calling the service after every restart.

@marc-hanheide please have a look. No big changes.
