### PR TITLE
a modal dialog can be displayed (see README.md for details)

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,5 +224,32 @@ Then you can call the `marathon_touch_gui` functions. To test you can cycle thro
 ```bash
 rosrun marathon_touch_gui demo.py 
 ```
+## Modal Dialog
+
+By publishing a `strands_webserver/ModalDlg` message on the `/strands_webserver/modal_dialog` topic a modal dialog can be triggered hovering above any window display. This is useful for system notifications. The `strands_webserver/ModalDlg` is defined as follows:
+
+```
+string title
+string content
+bool show
+```
+
+The modal dialog can be closed by the user using a little close item in the top right corner, it can remotely be hidden, by setting `show` to false. Here is an example to display the dialog box:
+
+```
+rostopic pub /strands_webserver/modal_dialog strands_webserver/ModalDlg "title: 'Nice Title'
+content: '<b>test</b> <a href="https://github.com/strands-project/aaf_deployment">AAF</a>'
+show: true"
+```
+
+To hide it again, simply publish
+
+```
+rostopic pub /strands_webserver/modal_dialog strands_webserver/ModalDlg "title: ''
+content: ''
+show: false"
+```
+
+Both, title and content can contain valid HTML.
 
 

--- a/strands_webserver/CMakeLists.txt
+++ b/strands_webserver/CMakeLists.txt
@@ -28,10 +28,10 @@ catkin_python_setup()
 #######################################
 
 # Generate messages in the 'msg' folder
-# add_message_files(
-#   FILES
-#   ServerAddress.msg
-# )
+add_message_files(
+  FILES
+  ModalDlg.msg
+)
 
 ## Generate services in the 'srv' folder
 add_service_files(

--- a/strands_webserver/data/main.html
+++ b/strands_webserver/data/main.html
@@ -112,6 +112,7 @@ $def with (name)
                     }
 
                 });
+                register_model_dlg_topic();
                 document.getElementById("content").innerHTML = "Ready; display = "+window.display_number;
             }
 
@@ -119,6 +120,32 @@ $def with (name)
                 page_topic.unsubscribe();
                 console.log("Stoped subscription.");
             }
+
+
+          function register_model_dlg_topic() {
+            var dlgTopic = new ROSLIB.Topic({
+                ros : ros,
+                name : '$:name/modal_dialog',
+                messageType : 'strands_webserver/ModalDlg'
+            });
+            console.log("register DLG");
+            dlgTopic.subscribe(function(message) {
+                // Formats the pose for outputting.
+                document.getElementById("modal-body-title").innerHTML=message.title;
+                document.getElementById("modal-body-text").innerHTML=message.content;
+
+                if (message.show) {
+                    $$('#notification_dlg').modal('show');
+                }
+                else {
+                    $$('#notification_dlg').modal('hide');
+                }
+
+            });
+            console.log("register DLG done");
+
+          }
+
 
 
             // Register the display with the manager
@@ -157,6 +184,24 @@ $def with (name)
 
 
         </script>
+
+<div class="modal fade" id="notification_dlg">
+  <div class="modal-dialog">
+    <div class="modal-content" >
+      <div class="modal-header">
+        <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+        <h4 class="modal-title"><div id="modal-body-title">Notification</div></h4>
+      </div>
+      <div class="modal-body">
+        <div id="modal-body-text"></div>
+      </div>
+<!--       <div class="modal-footer">
+        <button onclick="emergency_stop();" type="button" class="btn btn-danger btn-default" data-dismiss="modal">Notfall auslösen</button>
+        <button type="button" class="btn" data-dismiss="modal">Zurück zum Normalbetrieb</button>
+      </div>
+ -->    </div><!-- /.modal-content -->
+  </div><!-- /.modal-dialog -->
+
 
 	</body>
 </html>

--- a/strands_webserver/msg/ModalDlg.msg
+++ b/strands_webserver/msg/ModalDlg.msg
@@ -1,0 +1,3 @@
+string title
+string content
+bool show


### PR DESCRIPTION
This introduces a new feature into the strands_webserver. A modal dialog box can be displayed (on all displays) by publishing on a topic. This is needed for the AAF deployment to be able to communicate important system-related notifications to the user. Details can be found in the [README.md](https://github.com/strands-project/strands_ui/blob/modal_dlg/README.md#modal-dialog)
